### PR TITLE
fix: support fonts with weird bold

### DIFF
--- a/TMessagesProj/src/main/java/com/exteragram/messenger/utils/FontUtils.java
+++ b/TMessagesProj/src/main/java/com/exteragram/messenger/utils/FontUtils.java
@@ -1,0 +1,70 @@
+package com.exteragram.messenger.utils;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Typeface;
+
+import org.telegram.messenger.AndroidUtilities;
+import org.telegram.messenger.FileLog;
+import org.telegram.messenger.LocaleController;
+
+import java.util.List;
+
+public class FontUtils {
+
+    private static final String TEST_TEXT;
+    private static final int CANVAS_SIZE = AndroidUtilities.dp(12);
+    private static final Paint PAINT = new Paint() {{
+        setTextSize(CANVAS_SIZE);
+        setAntiAlias(false);
+        setSubpixelText(false);
+        setFakeBoldText(false);
+    }};
+
+    private static Boolean mediumWeightSupported = null;
+    private static Boolean italicSupported = null;
+
+    static {
+        if (List.of("zh", "ja", "ko").contains(LocaleController.getInstance().getCurrentLocale().getLanguage())) {
+            TEST_TEXT = "日";
+        } else {
+            TEST_TEXT = "R";
+        }
+    }
+
+    public static boolean isMediumWeightSupported() {
+        if (mediumWeightSupported == null) {
+            mediumWeightSupported = testTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+            FileLog.d("mediumWeightSupported = " + mediumWeightSupported);
+        }
+        return mediumWeightSupported;
+    }
+
+    public static boolean isItalicSupported() {
+        if (italicSupported == null) {
+            italicSupported = testTypeface(Typeface.create("sans-serif", Typeface.ITALIC));
+            FileLog.d("italicSupported = " + italicSupported);
+        }
+        return italicSupported;
+    }
+
+    private static boolean testTypeface(Typeface typeface) {
+        Canvas canvas = new Canvas();
+
+        Bitmap bitmap1 = Bitmap.createBitmap(CANVAS_SIZE, CANVAS_SIZE, Bitmap.Config.ALPHA_8);
+        canvas.setBitmap(bitmap1);
+        PAINT.setTypeface(null);
+        canvas.drawText(TEST_TEXT, 0, CANVAS_SIZE, PAINT);
+
+        Bitmap bitmap2 = Bitmap.createBitmap(CANVAS_SIZE, CANVAS_SIZE, Bitmap.Config.ALPHA_8);
+        canvas.setBitmap(bitmap2);
+        PAINT.setTypeface(typeface);
+        canvas.drawText(TEST_TEXT, 0, CANVAS_SIZE, PAINT);
+
+        boolean supported = !bitmap1.sameAs(bitmap2);
+        AndroidUtilities.recycleBitmaps(List.of(bitmap1, bitmap2));
+        return supported;
+    }
+}
+

--- a/TMessagesProj/src/main/java/org/telegram/messenger/AndroidUtilities.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/AndroidUtilities.java
@@ -117,6 +117,7 @@ import androidx.viewpager.widget.ViewPager;
 
 import com.android.internal.telephony.ITelephony;
 import com.exteragram.messenger.ExteraConfig;
+import com.exteragram.messenger.utils.FontUtils;
 import com.google.android.exoplayer2.util.Consumer;
 import com.google.android.gms.auth.api.phone.SmsRetriever;
 import com.google.android.gms.auth.api.phone.SmsRetrieverClient;
@@ -1743,10 +1744,18 @@ public class AndroidUtilities {
                                 t = Typeface.create("sans-serif-condensed", Typeface.BOLD);
                                 break;
                             case TYPEFACE_ROBOTO_MEDIUM_ITALIC:
-                                t = Build.VERSION.SDK_INT >= 28 ? Typeface.create(Typeface.SANS_SERIF, 500, true) : Typeface.create("sans-serif-medium", Typeface.ITALIC);
+                                if (FontUtils.isMediumWeightSupported()) {
+                                    t = Typeface.create("sans-serif-medium", Typeface.ITALIC);
+                                } else {
+                                    t = Typeface.create("sans-serif", Typeface.BOLD_ITALIC);
+                                }
                                 break;
                             case TYPEFACE_ROBOTO_MEDIUM:
-                                t = Build.VERSION.SDK_INT >= 28 ? Typeface.create(Typeface.SANS_SERIF, 500, false) : Typeface.create("sans-serif-medium", Typeface.NORMAL);
+                                if (FontUtils.isMediumWeightSupported()) {
+                                    t = Typeface.create("sans-serif-medium", Typeface.NORMAL);
+                                } else {
+                                    t = Typeface.create("sans-serif", Typeface.BOLD);
+                                }
                                 break;
                             case TYPEFACE_ROBOTO_ITALIC:
                                 t = Build.VERSION.SDK_INT >= 28 ? Typeface.create(Typeface.SANS_SERIF, 400, true) : Typeface.create("sans-serif", Typeface.ITALIC);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/TextStyleSpan.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/TextStyleSpan.java
@@ -13,6 +13,8 @@ import android.graphics.Typeface;
 import android.text.TextPaint;
 import android.text.style.MetricAffectingSpan;
 
+import com.exteragram.messenger.utils.FontUtils;
+
 import org.telegram.messenger.AndroidUtilities;
 import org.telegram.tgnet.TLRPC;
 import org.telegram.ui.ActionBar.Theme;
@@ -69,6 +71,14 @@ public class TextStyleSpan extends MetricAffectingSpan {
                 p.setFlags(p.getFlags() &~ Paint.STRIKE_THRU_TEXT_FLAG);
             }
 
+            if ((flags & FLAG_STYLE_BOLD) != 0 && !FontUtils.isMediumWeightSupported()) {
+                p.setStrokeWidth(0.65f);
+                p.setStyle(Paint.Style.FILL_AND_STROKE);
+            }
+            if ((flags & FLAG_STYLE_ITALIC) != 0 && !FontUtils.isItalicSupported()) {
+                p.setTextSkewX(-0.25f);
+            }
+
             if ((flags & FLAG_STYLE_SPOILER_REVEALED) != 0) {
                 p.bgColor = Theme.getColor(Theme.key_chats_archivePullDownBackground);
             }
@@ -77,11 +87,11 @@ public class TextStyleSpan extends MetricAffectingSpan {
         public Typeface getTypeface() {
             if ((flags & FLAG_STYLE_MONO) != 0 || (flags & FLAG_STYLE_QUOTE) != 0) {
                 return Typeface.MONOSPACE;
-            } else if ((flags & FLAG_STYLE_BOLD) != 0 && (flags & FLAG_STYLE_ITALIC) != 0) {
+            } else if ((flags & FLAG_STYLE_BOLD) != 0 && (flags & FLAG_STYLE_ITALIC) != 0 && FontUtils.isMediumWeightSupported() && FontUtils.isItalicSupported()) {
                 return AndroidUtilities.getTypeface(AndroidUtilities.TYPEFACE_ROBOTO_MEDIUM_ITALIC);
-            } else if ((flags & FLAG_STYLE_BOLD) != 0) {
+            } else if ((flags & FLAG_STYLE_BOLD) != 0 && FontUtils.isMediumWeightSupported()) {
                 return AndroidUtilities.getTypeface("fonts/rmedium.ttf");
-            } else if ((flags & FLAG_STYLE_ITALIC) != 0) {
+            } else if ((flags & FLAG_STYLE_ITALIC) != 0 && FontUtils.isItalicSupported()) {
                 return AndroidUtilities.getTypeface(AndroidUtilities.TYPEFACE_ROBOTO_ITALIC);
             } else {
                 return null;


### PR DESCRIPTION
Imported from Nekogram

before:
![image](https://github.com/exteraSquad/exteraGram/assets/110727638/f11ae177-2349-4e92-9d24-4d79ebc4c3ce)

after:
![image](https://github.com/exteraSquad/exteraGram/assets/110727638/a4ad2040-4ef6-4aaf-be4b-db93ac26945c)
